### PR TITLE
SMPdesign/SMPdesign.tex: Fixed a minor misspelling

### DIFF
--- a/SMPdesign/SMPdesign.tex
+++ b/SMPdesign/SMPdesign.tex
@@ -39,7 +39,7 @@ This chapter will also look at some specific problems, including:
 \label{sec:SMPdesign:Problems Quality Assessment}
 \item	Selecting the right granularity of partitioning.
 \label{sec:SMPdesign:Problems Granularity}
-\item	Comcurrent designs for applications that do not fully partition.
+\item	Concurrent designs for applications that do not fully partition.
 \label{sec:SMPdesign:Problems Parallel Fastpath}
 \item	Obtaining more than 2x speedup from two CPUs.
 \label{sec:SMPdesign:Problems Maze}


### PR DESCRIPTION
This commit fixes a minor misspelling.

Signed-off-by: Forouhar Mohammadpanah <forouhar.linux@gmail.com>
